### PR TITLE
Updates to GenericJMX plugin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2051,6 +2051,7 @@ dist_noinst_JAVA = \
 	bindings/java/org/collectd/java/GenericJMXConfConnection.java \
 	bindings/java/org/collectd/java/GenericJMXConfMBean.java \
 	bindings/java/org/collectd/java/GenericJMXConfValue.java \
+	bindings/java/org/collectd/java/GenericJMXUtils.java \
 	bindings/java/org/collectd/java/JMXMemory.java
 
 collectd-api.jar: $(JAVA_TIMESTAMP_FILE)

--- a/bindings/java/org/collectd/java/GenericJMXConfConnection.java
+++ b/bindings/java/org/collectd/java/GenericJMXConfConnection.java
@@ -52,7 +52,6 @@ class GenericJMXConfConnection
   private String _host = null;
   private String _service_name = null;
   private String _instance_prefix = null;
-  private String _monitor_id = null;
   private String _service_url = null;
   private String _plugin_name = null;
   private JMXConnector _jmx_connector = null;
@@ -254,12 +253,6 @@ class GenericJMXConfConnection
         if (tmp != null)
           this._instance_prefix = tmp;
       }
-      else if (child.getKey ().equalsIgnoreCase ("MonitorId"))
-      {
-        String tmp = getConfigString (child);
-        if (tmp != null)
-          this._monitor_id = tmp;
-      }
       else if (child.getKey ().equalsIgnoreCase ("CustomDimension"))
       {
         Map<String, String> tmp = getConfigStringPair (child);
@@ -325,7 +318,7 @@ class GenericJMXConfConnection
       int status;
 
       status = this._mbeans.get (i).query (this._mbean_connection, pd,
-          this._instance_prefix, this._monitor_id, this._custom_dimensions);
+          this._instance_prefix, this._custom_dimensions);
       if (status != 0)
       {
         disconnect ();

--- a/bindings/java/org/collectd/java/GenericJMXConfConnection.java
+++ b/bindings/java/org/collectd/java/GenericJMXConfConnection.java
@@ -52,7 +52,7 @@ class GenericJMXConfConnection
   private String _host = null;
   private String _service_name = null;
   private String _instance_prefix = null;
-  private String _instance_suffix = null;
+  private String _monitor_id = null;
   private String _service_url = null;
   private JMXConnector _jmx_connector = null;
   private MBeanServerConnection _mbean_connection = null;
@@ -223,11 +223,11 @@ class GenericJMXConfConnection
         if (tmp != null)
           this._instance_prefix = tmp;
       }
-      else if (child.getKey ().equalsIgnoreCase ("InstanceSuffix"))
+      else if (child.getKey ().equalsIgnoreCase ("MonitorId"))
       {
         String tmp = getConfigString (child);
         if (tmp != null)
-          this._instance_suffix = tmp;
+          this._monitor_id = tmp;
       }
       else if (child.getKey ().equalsIgnoreCase ("Collect"))
       {
@@ -281,7 +281,7 @@ class GenericJMXConfConnection
       int status;
 
       status = this._mbeans.get (i).query (this._mbean_connection, pd,
-          this._instance_prefix, this._instance_suffix);
+          this._instance_prefix, this._monitor_id);
       if (status != 0)
       {
         disconnect ();

--- a/bindings/java/org/collectd/java/GenericJMXConfConnection.java
+++ b/bindings/java/org/collectd/java/GenericJMXConfConnection.java
@@ -54,6 +54,7 @@ class GenericJMXConfConnection
   private String _instance_prefix = null;
   private String _monitor_id = null;
   private String _service_url = null;
+  private String _plugin_name = null;
   private JMXConnector _jmx_connector = null;
   private MBeanServerConnection _mbean_connection = null;
   private List<GenericJMXConfMBean> _mbeans = null;
@@ -245,6 +246,12 @@ class GenericJMXConfConnection
           this._mbeans.add (mbean);
         }
       }
+      else if (child.getKey ().equalsIgnoreCase ("Plugin"))
+      {
+          String tmp = getConfigString (child);
+          if (tmp != null)
+            this._plugin_name = tmp;
+      }
       else
         throw (new IllegalArgumentException ("Unknown option: "
               + child.getKey ()));
@@ -274,7 +281,8 @@ class GenericJMXConfConnection
     pd = new PluginData ();
     pd.setHost (this.getHost ());
 
-    pd.setPlugin ("GenericJMX");
+    // Use provided plugin name if applicable
+    pd.setPlugin (this._plugin_name == null ? "GenericJMX" : this._plugin_name);
 
     for (int i = 0; i < this._mbeans.size (); i++)
     {

--- a/bindings/java/org/collectd/java/GenericJMXConfMBean.java
+++ b/bindings/java/org/collectd/java/GenericJMXConfMBean.java
@@ -143,6 +143,12 @@ class GenericJMXConfMBean
         cv = new GenericJMXConfValue (child);
         this._values.add (cv);
       }
+      else if (child.getKey ().equalsIgnoreCase ("Dimension"))
+      {
+        String tmp = getConfigString (child);
+        if (tmp != null)
+          this._dimensions.add(tmp);
+      }
       else
         throw (new IllegalArgumentException ("Unknown option: "
               + child.getKey ()));
@@ -232,10 +238,31 @@ class GenericJMXConfMBean
         instance.append (instanceList.get (i));
       }
 
-      //TODO (Akash): Add support to pick MBean properties as dimensions
+      for (int i = 0; i < this._dimensions.size (); i++)
+      {
+        String dimensionName;
+        String dimensionValue;
+
+        dimensionName = this._dimensions.get (i);
+        dimensionValue = objName.getKeyProperty (dimensionName);
+        if (dimensionValue == null)
+        {
+          Collectd.logError ("GenericJMXConfMBean: "
+              + "No such property in object name: " + dimensionName);
+        }
+        else
+        {
+          dimensions.add (dimensionName + "=" + dimensionValue);
+        }
+      }
 
       // Add monitorID required by the SignalFx Agent
       dimensions.add("monitorID=" + monitor_id);
+
+      /*
+       * Append dimensions on to plugin instance in following format
+       *                   [dim1=val1,dim2=val2]
+       */
 
       String pluginInstance = instance.toString() + "[" + join(",", dimensions) + "]";
       pd_tmp.setPluginInstance (pluginInstance);

--- a/bindings/java/org/collectd/java/GenericJMXConfMBean.java
+++ b/bindings/java/org/collectd/java/GenericJMXConfMBean.java
@@ -269,7 +269,7 @@ class GenericJMXConfMBean
        *                   [dim1=val1,dim2=val2]
        */
 
-      String pluginInstance = instance.toString() + "[" + join(",", dimensions) + "]";
+      String pluginInstance = instance.toString() + "[" + GenericJMXUtils.join(",", dimensions) + "]";
       pd_tmp.setPluginInstance (pluginInstance);
 
       Collectd.logDebug ("GenericJMXConfMBean: instance = " + instance.toString ());
@@ -280,22 +280,6 @@ class GenericJMXConfMBean
 
     return (0);
   } /* }}} void query */
-
-  private String join (String separator, List<String> list) /* {{{ */
-  {
-    StringBuffer sb;
-
-    sb = new StringBuffer ();
-
-    for (int i = 0; i < list.size (); i++)
-    {
-      if (i > 0)
-        sb.append (separator);
-      sb.append (list.get (i));
-    }
-
-    return (sb.toString ());
-   } /* }}} String join */
 }
 
 /* vim: set sw=2 sts=2 et fdm=marker : */

--- a/bindings/java/org/collectd/java/GenericJMXConfMBean.java
+++ b/bindings/java/org/collectd/java/GenericJMXConfMBean.java
@@ -169,7 +169,7 @@ class GenericJMXConfMBean
   } /* }}} */
 
   public int query (MBeanServerConnection conn, PluginData pd, /* {{{ */
-      String instance_prefix, String monitor_id, Map<String, String> custom_dimensions)
+      String instance_prefix, Map<String, String> custom_dimensions)
   {
     Set<ObjectName> names;
     Iterator<ObjectName> iter;
@@ -256,9 +256,6 @@ class GenericJMXConfMBean
           dimensions.add (dimensionName + "=" + dimensionValue);
         }
       }
-
-      // Add monitorID required by the SignalFx Agent
-      dimensions.add("monitorID=" + monitor_id);
 
       // Add other connection level custom dimensions
       if (custom_dimensions != null) {

--- a/bindings/java/org/collectd/java/GenericJMXConfMBean.java
+++ b/bindings/java/org/collectd/java/GenericJMXConfMBean.java
@@ -28,6 +28,7 @@ package org.collectd.java;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.ArrayList;
 
@@ -168,7 +169,7 @@ class GenericJMXConfMBean
   } /* }}} */
 
   public int query (MBeanServerConnection conn, PluginData pd, /* {{{ */
-      String instance_prefix, String monitor_id)
+      String instance_prefix, String monitor_id, Map<String, String> custom_dimensions)
   {
     Set<ObjectName> names;
     Iterator<ObjectName> iter;
@@ -258,6 +259,13 @@ class GenericJMXConfMBean
 
       // Add monitorID required by the SignalFx Agent
       dimensions.add("monitorID=" + monitor_id);
+
+      // Add other connection level custom dimensions
+      if (custom_dimensions != null) {
+        for(String key: custom_dimensions.keySet()) {
+          dimensions.add(key + "=" + custom_dimensions.get(key));
+        }
+      }
 
       /*
        * Append dimensions on to plugin instance in following format

--- a/bindings/java/org/collectd/java/GenericJMXConfValue.java
+++ b/bindings/java/org/collectd/java/GenericJMXConfValue.java
@@ -85,7 +85,7 @@ class GenericJMXConfValue
     if (obj instanceof String)
     {
       String str = (String) obj;
-      
+
       try
       {
         if (ds_type == DataSource.TYPE_GAUGE)
@@ -420,7 +420,7 @@ class GenericJMXConfValue
     for (int i = 0; i < list.size (); i++)
     {
       if (i > 0)
-        sb.append ("-");
+        sb.append (separator);
       sb.append (list.get (i));
     }
 

--- a/bindings/java/org/collectd/java/GenericJMXConfValue.java
+++ b/bindings/java/org/collectd/java/GenericJMXConfValue.java
@@ -411,22 +411,6 @@ class GenericJMXConfValue
     }
   } /* }}} Object queryAttribute */
 
-  private String join (String separator, List<String> list) /* {{{ */
-  {
-    StringBuffer sb;
-
-    sb = new StringBuffer ();
-
-    for (int i = 0; i < list.size (); i++)
-    {
-      if (i > 0)
-        sb.append (separator);
-      sb.append (list.get (i));
-    }
-
-    return (sb.toString ());
-  } /* }}} String join */
-
   private String getConfigString (OConfigItem ci) /* {{{ */
   {
     List<OConfigValue> values;
@@ -629,9 +613,9 @@ class GenericJMXConfValue
 
     if (this._instance_prefix != null)
       instancePrefix = new String (this._instance_prefix
-          + join ("-", instanceList));
+          + GenericJMXUtils.join ("-", instanceList));
     else
-      instancePrefix = join ("-", instanceList);
+      instancePrefix = GenericJMXUtils.join ("-", instanceList);
 
     /*
      * Build a list of `Object's which is then passed to `submitTable' and

--- a/bindings/java/org/collectd/java/GenericJMXUtils.java
+++ b/bindings/java/org/collectd/java/GenericJMXUtils.java
@@ -1,0 +1,23 @@
+package org.collectd.java;
+
+import java.util.List;
+
+// Class holds common util methods used by other classes
+class GenericJMXUtils {
+  static String join (String separator, List<String> list) /* {{{ */
+  {
+   StringBuffer sb;
+
+   sb = new StringBuffer ();
+
+   for (int i = 0; i < list.size (); i++)
+   {
+     if (i > 0) {
+       sb.append (separator);
+     }
+     sb.append (list.get (i));
+   }
+
+   return (sb.toString ());
+  } /* }}} String join */
+ }


### PR DESCRIPTION
Changes 
- Mechanism to collect properties from MBeans as dimensions.
- Updating the way we add monitorID to GenericJMX plugins. We currently use InstanceSuffix in the Connection block to add this dimension to plugin instance. Added a CustomDimension config option in the connection block through which monitorID can be passed
- Optional Plugin field in the Connection block
- Bug fix in GenericJMXConfValue join method